### PR TITLE
initial cli to copy a run across experiments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 # pirama
+this repo contains a CLI to facilitate the steps to maintain a
+collection of benchmarks or leaderboards using mlflow
+
+## authentication
+set the credentials as environment variables before using the CLI
+
+``` shell
+export MLFLOW_TRACKING_USERNAME=
+export MLFLOW_TRACKING_PASSWORD=
+```
+
+## usage
+following POSIX standards you can get a message on how to use the command:
+
+``` shell
+$ python cli.py -h
+copy runs across mlflow experiments
+
+usage:
+  pirama [options]
+
+options:
+ -m --metric=<name>    name of the performance metric used to identify the best run in an experiment. ignored if a run id is provided.
+ -r --run=<id>         run from which to read data.
+ -s --source=<id>      id of the experiment from which to copy data. cannot be used together with -r. if used, -m is required as well.
+ -t --target=<id>      target experiment id in which a new run will be created and data logged.
+ -h --help             show this message.
+```

--- a/cli.py
+++ b/cli.py
@@ -7,8 +7,8 @@ usage:
 options:
  -m --metric=<name>    name of the performance metric used to identify the best run in an experiment. ignored if a run id is provided.
  -r --run=<id>         run from which to read data.
- -s --source=<id>      id of the experiment from which to copy data. cannot be used together with -r. if used, -m is required as well.
- -t --target=<id>      target experiment id in which a new run will be created and data logged.
+ -s --source=<name>    name of the experiment from which to copy data. cannot be used together with -r. if used, -m is required as well.
+ -t --target=<name>    name of the target experiment in which a new run will be created and data logged.
  -h --help             show this message.
 '''
 import logging
@@ -18,15 +18,18 @@ import docopt
 import mlflow
 
 logger = logging.getLogger('pirama')
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.INFO)
 
-client = mlflow.tracking.MlflowClient()
+client = mlflow.tracking.MlflowClient(tracking_uri='https://mlflow.ouva.dev')
 
 
-def create_run(src=None, exid=None):
-    logger.debug(f'creating new run in experiment {exid} starting from run {src}')
+def create_run(src=None, exname:str = None):
+    if not exname:
+        raise ValueError('cannot create run without an experiment name')
+    logger.debug(f'creating new run in experiment {exname} starting from run {src}')
     # Create a new run in the destination experiment
-    dest_run = client.create_run(exid)
+    experiment = client.get_experiment_by_name(name=exname)
+    dest_run = client.create_run(experiment.experiment_id)
     # Log parameters, metrics, and tags
     for key, value in src.data.params.items():
         client.log_param(dest_run.info.run_id, key, value)
@@ -41,16 +44,21 @@ def create_run(src=None, exid=None):
 
 
 def read_run(runid: str):
+    if not runid:
+        logger.error('run id (-r) is required to copy data from one run into another experiment. see -h for more help.')
+        sys.exit(1)
     logger.debug(f'reading run {runid}')
     run = client.get_run(runid)
-    logger.info(f'fetched data from run {run}')
+    logger.info(f'fetched data from run {run.info}')
     return run
-
 
 
 def main():
     args = docopt.docopt(__doc__)
-    read_run(args['--run'])
+    runid = args['--run']
+    run = read_run(runid)
+    exname = args['--target']
+    create_run(src=run, exname=exname)
 
 if __name__ == '__main__':
     main()

--- a/cli.py
+++ b/cli.py
@@ -20,9 +20,37 @@ import mlflow
 logger = logging.getLogger('pirama')
 logging.basicConfig(level=logging.DEBUG)
 
+client = mlflow.tracking.MlflowClient()
+
+
+def create_run(src=None, exid=None):
+    logger.debug(f'creating new run in experiment {exid} starting from run {src}')
+    # Create a new run in the destination experiment
+    dest_run = client.create_run(exid)
+    # Log parameters, metrics, and tags
+    for key, value in src.data.params.items():
+        client.log_param(dest_run.info.run_id, key, value)
+
+    for key, value in src.data.metrics.items():
+        client.log_metric(dest_run.info.run_id, key, value)
+
+    for key, value in src.data.tags.items():
+        client.set_tag(dest_run.info.run_id, key, value)
+
+    logger.info(f'created new run as {dest_run}')
+
+
+def read_run(runid: str):
+    logger.debug(f'reading run {runid}')
+    run = client.get_run(runid)
+    logger.info(f'fetched data from run {run}')
+    return run
+
+
 
 def main():
-    pass
+    args = docopt.docopt(__doc__)
+    read_run(args['--run'])
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION

out of scope:
- find the best run in the experiment
- create target experiment if it doesn't already exist

manually tested:

```shell
(.venv) cesar@eve:~/src/pirama
$ python cli.py -r a0a9eaa2d5784eab876ea4f7caa57699 -t Default
INFO:pirama:fetched data from run <RunInfo: artifact_uri='s3://ouva-mlflow/3/a0a9eaa2d5784eab876ea4f7caa57699/artifacts', end_time=1690683279952, experiment_id='3', lifecycle_stage='active', run_id='a0a9eaa2d5784eab876ea4f7caa57699', run_name='Finetune - Avasure/Caregility', run_uuid='a0a9eaa2d5784eab876ea4f7caa57699', start_time=1690546457088, status='FINISHED', user_id='aysun'>
INFO:pirama:created new run as <Run: data=<RunData: metrics={}, params={}, tags={'mlflow.runName': 'placid-shoat-261'}>, info=<RunInfo: artifact_uri='s3://ouva-mlflow/0/7c55d540760b4590aeca15cb0b53ab4d/artifacts', end_time=None, experiment_id='0', lifecycle_stage='active', run_id='7c55d540760b4590aeca15cb0b53ab4d', run_name='placid-shoat-261', run_uuid='7c55d540760b4590aeca15cb0b53ab4d', start_time=1696477333086, status='RUNNING', user_id='unknown'>, inputs=<RunInputs: dataset_inputs=[]>>
```